### PR TITLE
Remove unused prop-types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "np": "^5.0.3",
     "prettier": "1.18.2",
     "pretty-quick": "^1.8.0",
-    "prop-types": "^15.6.2",
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
     "tslint": "^5.18.0",
@@ -51,7 +50,6 @@
     "tslint-react-hooks": "^2.1.1"
   },
   "peerDependencies": {
-    "prop-types": "^15.0.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },


### PR DESCRIPTION
Removes an unnecessary warning when installing the package.

```
"react-use-clipboard@1.0.0" has unmet peer dependency "prop-types@^15.0.0".
```