### PR TITLE
Update peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "tslint-react-hooks": "^2.1.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17",
+    "react-dom": "^16.8.0 || ^17"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Removes warnings when installing the package on a project with React v17

```
"peer dep missing: react@^16.8.0, required by react-use-clipboard@1.0.1"
"peer dep missing: react-dom@^16.8.0, required by react-use-clipboard@1.0.1"
```