### PR TITLE
Remove modern JS from dist to work with Next.js

### DIFF
--- a/.changeset/afraid-schools-burn.md
+++ b/.changeset/afraid-schools-burn.md
@@ -1,0 +1,5 @@
+---
+"react-use-clipboard": patch
+---
+
+Remove modern JS from dist to work with Next.js

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "source": "./src/index.tsx",
   "main": "./dist/react-use-clipboard.js",
-  "exports": "./dist/react-use-clipboard.modern.js",
   "module": "./dist/react-use-clipboard.module.js",
   "unpkg": "./dist/react-use-clipboard.umd.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Fixes #31.