### PR TITLE
Rename the function

### DIFF
--- a/.changeset/seven-buckets-draw.md
+++ b/.changeset/seven-buckets-draw.md
@@ -1,0 +1,5 @@
+---
+"react-use-clipboard": patch
+---
+
+Rename the default export function to `useClipboard` instead of `useCopyClipboard` for consistency with the package name.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,7 @@ interface IOptions {
   successDuration?: number;
 }
 
-export default function useCopyClipboard(
+export default function useClipboard(
   text: string,
   options?: IOptions
 ): [boolean, () => void] {


### PR DESCRIPTION
It will be more clear to use the name `useClipboard` instead of `useCopyClipboard` because:
1. It matches the examples in the README.md and the name of the package
2. the IntelliSense will show the function name as `useClipboard` instead of `useCopyClipboard` when we try to import it, as you can see in the image below:
![Screen Shot 2022-10-07 at 2 25 13 AM](https://user-images.githubusercontent.com/111672775/194439236-df61b79e-e15b-4beb-8780-02a2c970e46f.png)

